### PR TITLE
Allow assignment / comparison from enum values to enum types

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -1725,7 +1725,7 @@ namespace Microsoft.PowerFx.Core.Types
                     break;
 
                 case DKind.Enum:
-                    accepts = (Kind != type.Kind && type.Kind == DKind.Unknown) ||
+                    accepts = (Kind != type.Kind && (type.Kind == DKind.Unknown || EnumSuperkind == type.Kind)) ||
                               (EnumSuperkind == type.EnumSuperkind && EnumTreeAccepts(ValueTree, type.ValueTree, exact));
                     break;
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/FunctionCompilationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/FunctionCompilationTests.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerFx.Core.Public.Types;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Interpreter;
+using Xunit;
+
+namespace Microsoft.PowerFx.Tests
+{
+    public class FunctionCompilationTests
+    {
+        [Theory]
+        [InlineData("Switch(A, 2, \"two\", \"other\")")]
+        [InlineData("IfError(Text(A), Switch(FirstError.Kind, ErrorKind.Div0, \"Division by zero\", ErrorKind.Numeric, \"Numeric error\", \"Other error\"))")]
+        public void TestSwitchFunctionCompilation(string expression)
+        {
+            var engine = new RecalcEngine();
+            engine.UpdateVariable("A", 15);
+            var check = engine.Check(expression);
+            Assert.True(check.IsSuccess);
+            Assert.Null(check.Errors);
+            Assert.Equal(FormulaType.String, check.ReturnType);
+        }
+    }
+}


### PR DESCRIPTION
Currently an expression such as `IfError(variable, Switch(FirstError.Kind, ErrorKind.Div0, -1, ErrorKind.Numeric, -2, -3))` does not compile, because the value `ErrorKind.Div0` cannot be compared to `FirstError.Kind` - which is of type (numeric) enum. This change loosens the rule for acceptance of enum types so that their base type can be assigned (and compared) to them.